### PR TITLE
[Draft] Add support for doubles and refactor `ceq`

### DIFF
--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -754,6 +754,38 @@ namespace libDotNetClr
                     var result = numb1 ^ numb2;
                     stack.Add(MethodArgStack.Int32(result));
                 }
+                else if (item.OpCodeName == "shl")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb2 << numb1;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
+                else if (item.OpCodeName == "shr")
+                {
+                    var a = stack.Pop();
+                    var b = stack.Pop();
+
+                    if (a.type != StackItemType.Int32 || b.type != StackItemType.Int32)
+                    {
+                        clrError($"Error in {item.OpCodeName} opcode: type is not int32", "Internal CLR error");
+                        return null;
+                    }
+
+                    var numb1 = (int)a.value;
+                    var numb2 = (int)b.value;
+                    var result = numb2 >> numb1;
+                    stack.Add(MethodArgStack.Int32(result));
+                }
                 else if (item.OpCodeName == "not")
                 {
                     var a = stack.Pop();

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -649,22 +649,17 @@ namespace libDotNetClr
                 {
                     if (stack.Count < 2)
                         throw new Exception("There has to be 2 or more items on the stack for ceq instruction to work!");
-                    var numb1 = stack.Pop().value;
-                    var numb2 = stack.Pop().value;
+                    var a = stack.Pop();
+                    var b = stack.Pop();
 
-                    if (numb1 is float)
+                    if (a.type == b.type && a.type != StackItemType.Int32)
                     {
-                        if ((float)numb1 == (float)numb2)
-                        {
-                            stack.Add(MethodArgStack.Int32(1));
-                        }
-                        else
-                        {
-                            stack.Add(MethodArgStack.Int32(0));
-                        }
+                        stack.Add(MathOperations.Op(a, b, MathOperations.Operation.Equality));
                     }
                     else
                     {
+                        var numb1 = a.value;
+                        var numb2 = b.value;
                         int Numb1;
                         int Numb2;
 

--- a/DotNetClr/CLR/DotNetClr.cs
+++ b/DotNetClr/CLR/DotNetClr.cs
@@ -473,15 +473,8 @@ namespace libDotNetClr
                 //Push float64
                 else if (item.OpCodeName == "ldc.r8")
                 {
-                    //Puts an float32 with value onto the arg stack
-                    if (item.Operand is float)
-                    {
-                        stack.Add(MethodArgStack.Float64((float)item.Operand));
-                    }
-                    else
-                    {
-                        throw new NotImplementedException();
-                    }
+                    //Puts an float64 with value onto the arg stack
+                    stack.Add(MethodArgStack.Float64((double)item.Operand));
                 }
                 #endregion
                 #region conv* opcodes

--- a/LibDotNetParser/CILApi/IL/IlDecompiler.cs
+++ b/LibDotNetParser/CILApi/IL/IlDecompiler.cs
@@ -748,8 +748,8 @@ namespace LibDotNetParser.CILApi
                     }
                 case OpCodeOperandType.InlineR:
                     {
-                        var numb2 = BitConverter.ToSingle(code, Offset + 1);
-                        ret.Size += 4;
+                        var numb2 = BitConverter.ToDouble(code, Offset + 1);
+                        ret.Size += 8;
                         ret.Operand = numb2;
                         return ret;
                     }

--- a/LibDotNetParser/CILApi/MethodArgStack.cs
+++ b/LibDotNetParser/CILApi/MethodArgStack.cs
@@ -108,7 +108,7 @@ namespace LibDotNetParser
         {
             return new MethodArgStack() { type = StackItemType.Float32, value = value };
         }
-        public static MethodArgStack Float64(float value)
+        public static MethodArgStack Float64(double value)
         {
             return new MethodArgStack() { type = StackItemType.Float64, value = value };
         }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -578,6 +578,10 @@ namespace DotNetparserTester
             TestAssert((i ^ i2) == 0x183E5C72, "int32 bitwise xor");
             uint ui = 0x12345678;
             TestAssert(~ui == 0xEDCBA987, "uint32 bitwise not");
+            i = 0x12345678;
+            TestAssert((i >> 4) == 0x01234567, "int32 shift right");
+            i = 0x12345678;
+            TestAssert((i << 4) == 0x23456780, "int32 shift left");
 
             TestsComplete();
         }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -578,6 +578,10 @@ namespace DotNetparserTester
             TestAssert((i ^ i2) == 0x183E5C72, "int32 bitwise xor");
             uint ui = 0x12345678;
             TestAssert(~ui == 0xEDCBA987, "uint32 bitwise not");
+            long l1 = 5, l2 = 3;
+            TestAssert(l1 + l2 == 8L, "long addition");
+            double d1 = 5, d2 = 3.5;
+            TestAssert(d1 + d2 == 8.5, "double addition");
 
             TestsComplete();
         }


### PR DESCRIPTION
## General Notes

This PR builds upon #8 and adds support for `double` by refactoring the `ceq` instruction to use `MathOperations`

## Testing

Two new tests have been added to ensure that both `long` and `double` are now working with `ceq` and the other `MathOperations`.